### PR TITLE
Fix broken links on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,13 +22,13 @@
         <p class="view"><a href="https://github.com/UK-MAC">View My GitHub Profile</a></p>
 
         <img src="https://uk-mac.github.io/images/All_alpha_med.png" height="400px" width="300px">
-        <hr />  
+        <hr />
         <h1><a href="news.html">News</a></h1>
-        <hr />  
+        <hr />
         <h1><a href="about.html">About</a></h1>
-        <hr />  
+        <hr />
         <h1><a href="papers.html">Papers</a></h1>
-        <hr /> 
+        <hr />
 
       </header>
       <section>
@@ -38,7 +38,7 @@
 
 <h1>Mini-Apps</h1>
 <p>The UK-MAC page contains a selection of mini-apps, developed as part of collaborations with a number of UK based institutions.</p>
-<p><a href="http://uk-mac.github.com/CloverLeaf/">CloverLeaf</a> was the first of our mini-apps and was included in the <a href="https://mantevo.org/">Mantevo</a> 1.0 release.</p>
+<p><a href="http://uk-mac.github.io/CloverLeaf/">CloverLeaf</a> was the first of our mini-apps and was included in the <a href="https://mantevo.org/">Mantevo</a> 1.0 release.</p>
 <p>Mantevo is a collaborative suite of mini-apps from different research institutions aimed towards co-design, and was the recipient of an <a href="https://mantevo.org/mantevo-suite-1-0-chosen-for-rd-100-award/">R&D 100 award</a> in 2013.</p>
 
 <p>The work has been published in various papers although the original CloverLeaf paper should be considered the reference paper:</p>
@@ -49,7 +49,7 @@
 <h1>Codes</h1>
 
 <h2>
-<img src="http://uk-mac.github.io/CloverLeaf/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.com/CloverLeaf/">CloverLeaf</a>
+<img src="http://uk-mac.github.io/CloverLeaf/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.io/CloverLeaf/">CloverLeaf</a>
 </h2>
 
 <p>A hydrodynamics mini-app to solve the compressible Euler equations in 2D, using an explicit, second-order method.</p>
@@ -57,7 +57,7 @@
 <hr/>
 
 <h2>
-<img src="http://uk-mac.github.io/CloverLeaf3D/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.com/CloverLeaf3D/">CloverLeaf3D</a>
+<img src="http://uk-mac.github.io/CloverLeaf3D/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.io/CloverLeaf3D/">CloverLeaf3D</a>
 
 </h2>
 
@@ -67,21 +67,21 @@
 
 
 <h2>
-<img src="http://uk-mac.github.io/CleverLeaf/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.com/CleverLeaf/">CleverLeaf</a>
+<img src="http://uk-mac.github.io/CleverLeaf/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.io/CleverLeaf/">CleverLeaf</a>
 </h2>
 
 <p>CleverLeaf is an adaptive mesh refinement implementation of CloverLeaf using the SAMRAI library.</p>
 
 <hr/>
 <h2>
-<img src="http://uk-mac.github.io/CleverLeaf3D/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.com/CleverLeaf3D/">CleverLeaf3D - Coming Soon!</a>
+<img src="http://uk-mac.github.io/CleverLeaf3D/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.io/CleverLeaf3D/">CleverLeaf3D - Coming Soon!</a>
 </h2>
 
 <p>CleverLeaf is an adaptive mesh refinement implementation of CloverLeaf using the SAMRAI library in 3D.</p>
 
 <hr/>
 <h2>
-<img src="https://uk-mac.github.io/TeaLeaf/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.com/TeaLeaf/">TeaLeaf</a>
+<img src="https://uk-mac.github.io/TeaLeaf/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.io/TeaLeaf/">TeaLeaf</a>
 
 </h2>
 
@@ -89,7 +89,7 @@
 
 <hr/>
 <h2>
-<img src="http://uk-mac.github.io/TeaLeaf3D/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.com/TeaLeaf3D/">TeaLeaf3D</a>
+<img src="http://uk-mac.github.io/TeaLeaf3D/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.io/TeaLeaf3D/">TeaLeaf3D</a>
 
 </h2>
 
@@ -98,7 +98,7 @@
 
 <hr/>
 <h2>
-<img src="https://uk-mac.github.io/BookLeaf/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.com/BookLeaf/">BookLeaf</a>
+<img src="https://uk-mac.github.io/BookLeaf/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.io/BookLeaf/">BookLeaf</a>
 
 </h2>
 
@@ -108,7 +108,7 @@
 
 <!--
 <h2>
-<img src="http://uk-mac.github.io/BookLeaf3D/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.com/BookLeaf3D/">BookLeaf3D - Coming Soon!</a>
+<img src="http://uk-mac.github.io/BookLeaf3D/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.io/BookLeaf3D/">BookLeaf3D - Coming Soon!</a>
 
 </h2>
 
@@ -117,7 +117,7 @@
 <hr/>
 
 <h2>
-<img src="https://uk-mac.github.io/PalmLeaf/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.com/PalmLeaf/">PalmLeaf - Coming Soon!</a>
+<img src="https://uk-mac.github.io/PalmLeaf/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.io/PalmLeaf/">PalmLeaf - Coming Soon!</a>
 
 </h2>
 
@@ -126,7 +126,7 @@
 <hr/>
 
 <h2>
-<img src="http://uk-mac.github.io/PalmLeaf3D/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.com/PalmLeaf3D/">PalmLeaf3D - Coming Soon!</a>
+<img src="http://uk-mac.github.io/PalmLeaf3D/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.io/PalmLeaf3D/">PalmLeaf3D - Coming Soon!</a>
 
 </h2>
 
@@ -137,7 +137,7 @@
 
 
 <h2>
-<img src="http://uk-mac.github.io/DockLeaf/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.com/DockLeaf/">DockLeaf - Coming Soon!</a>
+<img src="http://uk-mac.github.io/DockLeaf/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.io/DockLeaf/">DockLeaf - Coming Soon!</a>
 
 </h2>
 
@@ -146,7 +146,7 @@
 <hr/>
 
 <h2>
-<img src="http://uk-mac.github.io/DockLeaf3D/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.com/DockLeaf3D/">DockLeaf3D - Coming Soon!</a>
+<img src="http://uk-mac.github.io/DockLeaf3D/images/logo_small.png" height="60px" width="60px" style="vertical-align: middle;"><a href="http://uk-mac.github.io/DockLeaf3D/">DockLeaf3D - Coming Soon!</a>
 
 </h2>
 
@@ -157,7 +157,7 @@
 
 <h1>Tools</h1>
 
-<h2><a href="http://uk-mac.github.com/WMTools/">WMTools</a></h2>
+<h2><a href="http://uk-mac.github.io/WMTools/">WMTools</a></h2>
 
 <p>Warwick Memory Tools - Suite of tools for parallel application memory consumption analysis.</p>
 
@@ -165,7 +165,7 @@
 
 <p><img src="https://uk-mac.github.io/images/redrobot.jpg" height="60px" width="60px" style="vertical-align: middle;"><a href="http://anne-wilson.co.uk//">Art work by Anne Wilson</a></p>
 <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
-      
+
       </section>
     </div>
     <script src="javascripts/scale.fix.js"></script>


### PR DESCRIPTION
# Error

[In 2021, GitHub pages domains ending in `github.com` were deprecated](https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/). As a result of this, the links on the index page of this site are broken, as noted in issue #1 .

![image](https://github.com/UK-MAC/uk-mac.github.com/assets/37504168/b6c90a81-ad22-4c02-8a7e-61d20a7c5f43)

# Fix

This pull request fixes the broken links by updating them to `.github.io`.

# Other notes

It is also likely wise to rename this repository from `uk-mac.github.com` to `uk-mac.github.io` for consistency with the change and to prevent future breakages.